### PR TITLE
~$chsh -s [`/~"]=$ setup.sh

### DIFF
--- a/pkg-setup.sh
+++ b/pkg-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+apt update && apt upgrade -y && 
+pkg install wget -y && 
+echo "clear && proot-distro login kali" >> $PREFIX/etc/bash.bashrc && wget -qO- https://raw.githubusercontent.com/xiv3r/proot-distro-kali/refs/heads/main/files/setup.sh | sh && 
+proot-distro login kali
+
+
+chsh -s ["/~"]=$
+cat /data/data/com.termux/files/usr/etc/bash.bashrc
+if [ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]; then
+        command_not_found_handle() {
+                /data/data/com.termux/files/usr/libexec/termux/command-not-found "~$1"
+
+                ["/~]$ pkg upgradeable
+chmod a+x $PREFIX
+[~]$ pkg upgradeable
+apt install -y proot-distro 
+###
+wget -O $PREFIX/etc/proot-distro/kali.sh https://raw.githubusercontent.com/xiv3r/proot-distro-kali/refs/heads/main/files/kali.sh
+###
+chmod a+x $PREFIX/etc/proot-distro/kali.sh
+###
+proot-distro install kali 
+
+***$$$$*** ~$chsh -s [`/~"]=$ [/~]=$pkg
+cat /data/data/com.termux/files/usr/etc/bash.bashrc
+if [ a+x /data/data/com.termux/files/
+usr/libexec/termux/cousr/libexec/termux/command-not-foundmmand-not-found ]; then


### PR DESCRIPTION
> #!/bin/sh
> 
> apt update && apt upgrade -y && 
> pkg install wget -y && 
> echo "clear && proot-distro login kali" >> $PREFIX/etc/bash.bashrc && wget -qO- https://raw.githubusercontent.com/xiv3r/proot-distro-kali/refs/heads/main/files/setup.sh | sh &&  proot-distro login kali
> 
> 
> chsh -s ["/~"]=$
> cat /data/data/com.termux/files/usr/etc/bash.bashrc if [ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]; then
>         command_not_found_handle() {
>                 /data/data/com.termux/files/usr/libexec/termux/command-not-found "~$1"
> 
>                 ["/~]$ pkg upgradeable
> chmod a+x $PREFIX
> [~]$ pkg upgradeable
> apt install -y proot-distro 
> ###
> wget -O $PREFIX/etc/proot-distro/kali.sh https://raw.githubusercontent.com/xiv3r/proot-distro-kali/refs/heads/main/files/kali.sh ###
> chmod a+x $PREFIX/etc/proot-distro/kali.sh
> ###
> proot-distro install kali 
> 
> ***$$$$*** ~$chsh -s [`/~"]=$ [/~]=$pkg
> cat /data/data/com.termux/files/usr/etc/bash.bashrc if [ a+x /data/data/com.termux/files/
> usr/libexec/termux/cousr/libexec/termux/command-not-foundmmand-not-found ]; then